### PR TITLE
Use stable version of Gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha1'
+        classpath 'com.android.tools.build:gradle:2.1.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
The current version of the project uses an alpha version of Gradle, which is a problem since it requires Java version 1.8

This PR changes the version of Gradle used to 2.1.2 which is the latest stable version (and uses Java 1.7 which is more widespread)
