### PR TITLE
Abstract FaceCameraSource

### DIFF
--- a/app/src/main/java/net/bonysoft/magicmirror/facerecognition/FaceCameraSource.java
+++ b/app/src/main/java/net/bonysoft/magicmirror/facerecognition/FaceCameraSource.java
@@ -1,0 +1,64 @@
+package net.bonysoft.magicmirror.facerecognition;
+
+import android.content.Context;
+
+import com.google.android.gms.vision.CameraSource;
+import com.google.android.gms.vision.MultiProcessor;
+import com.google.android.gms.vision.face.FaceDetector;
+import com.novoda.notils.logger.simple.Log;
+
+import java.io.IOException;
+
+public class FaceCameraSource implements FaceReactionSource {
+
+    private static final float CAMERA_SOURCE_REQUESTED_FPS = 30.0f;
+    private static final int CAMERA_SOURCE_WIDTH = 640;
+    private static final int CAMERA_SOURCE_HEIGHT = 360;
+    private CameraSource cameraSource;
+    private CameraSourcePreview preview;
+
+    public static FaceReactionSource createFrom(Context context,
+                                                FaceTracker.FaceListener faceListener,
+                                                CameraSourcePreview preview)
+            throws FaceDetectionUnavailableException {
+        FaceDetector detector = new FaceDetector.Builder(context)
+                .setClassificationType(FaceDetector.ALL_CLASSIFICATIONS)
+                .build();
+
+        detector.setProcessor(
+                new MultiProcessor.Builder<>(new FaceTracker.Factory(faceListener))
+                        .build()
+        );
+        if (!detector.isOperational()) {
+            throw new FaceDetectionUnavailableException("Detector is not Operational");
+        }
+        CameraSource cameraSource = new CameraSource.Builder(context, detector)
+                .setRequestedPreviewSize(CAMERA_SOURCE_WIDTH, CAMERA_SOURCE_HEIGHT)
+                .setFacing(CameraSource.CAMERA_FACING_FRONT)
+                .setRequestedFps(CAMERA_SOURCE_REQUESTED_FPS)
+                .build();
+        return new FaceCameraSource(cameraSource, preview);
+    }
+
+    public FaceCameraSource(CameraSource cameraSource, CameraSourcePreview preview) {
+        this.cameraSource = cameraSource;
+        this.preview = preview;
+    }
+
+    @Override
+    public void start() {
+        try {
+            preview.start(cameraSource);
+        } catch (IOException e) {
+            Log.e(e, "Unable to start camera source.");
+            cameraSource.release();
+            cameraSource = null;
+        }
+    }
+
+    @Override
+    public void release() {
+        cameraSource.release();
+        cameraSource = null;
+    }
+}

--- a/app/src/main/java/net/bonysoft/magicmirror/facerecognition/FaceCameraSource.java
+++ b/app/src/main/java/net/bonysoft/magicmirror/facerecognition/FaceCameraSource.java
@@ -52,13 +52,11 @@ public class FaceCameraSource implements FaceReactionSource {
         } catch (IOException e) {
             Log.e(e, "Unable to start camera source.");
             cameraSource.release();
-            cameraSource = null;
         }
     }
 
     @Override
     public void release() {
         cameraSource.release();
-        cameraSource = null;
     }
 }

--- a/app/src/main/java/net/bonysoft/magicmirror/facerecognition/FaceDetectionUnavailableException.java
+++ b/app/src/main/java/net/bonysoft/magicmirror/facerecognition/FaceDetectionUnavailableException.java
@@ -1,0 +1,7 @@
+package net.bonysoft.magicmirror.facerecognition;
+
+public class FaceDetectionUnavailableException extends Exception {
+    public FaceDetectionUnavailableException(String reason) {
+        super(reason);
+    }
+}

--- a/app/src/main/java/net/bonysoft/magicmirror/facerecognition/FaceReactionSource.java
+++ b/app/src/main/java/net/bonysoft/magicmirror/facerecognition/FaceReactionSource.java
@@ -1,0 +1,7 @@
+package net.bonysoft.magicmirror.facerecognition;
+
+public interface FaceReactionSource {
+    void start();
+
+    void release();
+}


### PR DESCRIPTION
Currently the only way of getting the user 'mood' is through the camera. This is a problematic for debugging purposes as you need to act like a clown in order to debug the app 😂 

This PR abstracts the `FaceReactionSource` so that we can swap out different 'sources' depending the need.

On a follow up PR: Allow fake face detection from the keyboard ⌨️ (https://github.com/danybony/magic-mirror-dashboard/pull/8)
