### PR TITLE
Trigger facial expression by using the Keyboard

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,4 +45,8 @@ dependencies {
     compile 'com.survivingwithandroid:weatherlib:1.6.0'
     compile 'com.survivingwithandroid:weatherlib_okhttpclient:1.6.0'
     compile 'com.squareup.okhttp:okhttp:2.0.0'
+
+    testCompile 'junit:junit:4.12'
+    testCompile 'org.easytesting:fest-assert-core:2.0M10'
+    testCompile "org.mockito:mockito-core:1.10.19"
 }

--- a/app/src/main/java/net/bonysoft/magicmirror/DeviceInformation.java
+++ b/app/src/main/java/net/bonysoft/magicmirror/DeviceInformation.java
@@ -4,6 +4,9 @@ import android.os.Build;
 
 public class DeviceInformation {
 
+    /**
+     * Taken from http://stackoverflow.com/a/21505193/1315110
+     */
     public boolean isEmulator() {
         return Build.FINGERPRINT.startsWith("generic")
                 || Build.FINGERPRINT.startsWith("unknown")

--- a/app/src/main/java/net/bonysoft/magicmirror/DeviceInformation.java
+++ b/app/src/main/java/net/bonysoft/magicmirror/DeviceInformation.java
@@ -1,0 +1,18 @@
+package net.bonysoft.magicmirror;
+
+import android.os.Build;
+
+public class DeviceInformation {
+
+    public boolean isEmulator() {
+        return Build.FINGERPRINT.startsWith("generic")
+                || Build.FINGERPRINT.startsWith("unknown")
+                || Build.MODEL.contains("google_sdk")
+                || Build.MODEL.contains("Emulator")
+                || Build.MODEL.contains("Android SDK built for x86")
+                || Build.MANUFACTURER.contains("Genymotion")
+                || (Build.BRAND.startsWith("generic") && Build.DEVICE.startsWith("generic"))
+                || "google_sdk".equals(Build.PRODUCT);
+    }
+
+}

--- a/app/src/main/java/net/bonysoft/magicmirror/FaceRecognitionActivity.java
+++ b/app/src/main/java/net/bonysoft/magicmirror/FaceRecognitionActivity.java
@@ -166,7 +166,6 @@ public class FaceRecognitionActivity extends AppCompatActivity {
             runOnUiThread(new Runnable() {
                 @Override
                 public void run() {
-                    Log.d(expression.name());
                     faceStatus.setText(expression.toString());
                 }
             });

--- a/app/src/main/java/net/bonysoft/magicmirror/FaceRecognitionActivity.java
+++ b/app/src/main/java/net/bonysoft/magicmirror/FaceRecognitionActivity.java
@@ -28,6 +28,7 @@ import net.bonysoft.magicmirror.facerecognition.KeyboardFaceSource;
 public class FaceRecognitionActivity extends AppCompatActivity {
 
     private static final int CAMERA_PERMISSION_REQUEST = 0;
+    private final DeviceInformation deviceInformation = new DeviceInformation();
 
     private FaceReactionSource faceSource;
     private CameraSourcePreview preview;
@@ -70,8 +71,7 @@ public class FaceRecognitionActivity extends AppCompatActivity {
     }
 
     private boolean isUsingCamera() {
-//        return BuildConfig.DEBUG;
-        return true;
+        return !deviceInformation.isEmulator();
     }
 
     private void keepScreenOn() {

--- a/app/src/main/java/net/bonysoft/magicmirror/facerecognition/FaceCameraSource.java
+++ b/app/src/main/java/net/bonysoft/magicmirror/facerecognition/FaceCameraSource.java
@@ -61,4 +61,14 @@ public class FaceCameraSource implements FaceReactionSource {
         cameraSource.release();
         cameraSource = null;
     }
+
+    @Override
+    public boolean onKeyDown(int keyCode) {
+        return false;
+    }
+
+    @Override
+    public boolean onKeyUp(int keyCode) {
+        return false;
+    }
 }

--- a/app/src/main/java/net/bonysoft/magicmirror/facerecognition/FaceReactionSource.java
+++ b/app/src/main/java/net/bonysoft/magicmirror/facerecognition/FaceReactionSource.java
@@ -4,4 +4,8 @@ public interface FaceReactionSource {
     void start();
 
     void release();
+
+    boolean onKeyDown(int keyCode);
+
+    boolean onKeyUp(int keyCode);
 }

--- a/app/src/main/java/net/bonysoft/magicmirror/facerecognition/KeyToFaceMappings.java
+++ b/app/src/main/java/net/bonysoft/magicmirror/facerecognition/KeyToFaceMappings.java
@@ -1,0 +1,32 @@
+package net.bonysoft.magicmirror.facerecognition;
+
+import android.view.KeyEvent;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class KeyToFaceMappings {
+
+    private final Map<Integer, FaceExpression> faceExpressions;
+
+    public static KeyToFaceMappings newInstance() {
+        Map<Integer, FaceExpression> expressions = new HashMap<>();
+        expressions.put(KeyEvent.KEYCODE_1, FaceExpression.SAD);
+        expressions.put(KeyEvent.KEYCODE_2, FaceExpression.NEUTRAL);
+        expressions.put(KeyEvent.KEYCODE_3, FaceExpression.HAPPY);
+        expressions.put(KeyEvent.KEYCODE_4, FaceExpression.JOYFUL);
+        return new KeyToFaceMappings(expressions);
+    }
+
+    public KeyToFaceMappings(Map<Integer, FaceExpression> faceExpressions) {
+        this.faceExpressions = faceExpressions;
+    }
+
+    public FaceExpression getFace(int keyCode) {
+        return faceExpressions.get(keyCode);
+    }
+
+    public boolean contains(int keyCode) {
+        return faceExpressions.containsKey(keyCode);
+    }
+}

--- a/app/src/main/java/net/bonysoft/magicmirror/facerecognition/KeyToFaceMappings.java
+++ b/app/src/main/java/net/bonysoft/magicmirror/facerecognition/KeyToFaceMappings.java
@@ -22,7 +22,7 @@ public class KeyToFaceMappings {
         this.faceExpressions = faceExpressions;
     }
 
-    public FaceExpression getFace(int keyCode) {
+    public FaceExpression getFaceFromKeyCode(int keyCode) {
         return faceExpressions.get(keyCode);
     }
 

--- a/app/src/main/java/net/bonysoft/magicmirror/facerecognition/KeyboardFaceSource.java
+++ b/app/src/main/java/net/bonysoft/magicmirror/facerecognition/KeyboardFaceSource.java
@@ -1,0 +1,57 @@
+package net.bonysoft.magicmirror.facerecognition;
+
+public class KeyboardFaceSource implements FaceReactionSource {
+
+    private static final FaceExpression NEUTRAL_EXPRESSION = FaceExpression.LOOKING;
+    private static final int KEY_NEUTRAL = -1;
+
+    private final FaceTracker.FaceListener faceListener;
+    private final KeyToFaceMappings mappings;
+
+    private int currentPress = KEY_NEUTRAL;
+
+    public KeyboardFaceSource(FaceTracker.FaceListener faceListener, KeyToFaceMappings mappings) {
+        this.faceListener = faceListener;
+        this.mappings = mappings;
+    }
+
+    public boolean onKeyDown(int keyCode) {
+        if (sameKeyCodeIsTriggered(keyCode) || isStillUnsupportedCode(keyCode)) {
+            return false;
+        }
+        FaceExpression faceExpression = mappings.getFace(keyCode);
+        if (faceExpression != null) {
+            currentPress = keyCode;
+            faceListener.onNewFace(faceExpression);
+            return true;
+        }
+        currentPress = KEY_NEUTRAL;
+        return false;
+    }
+
+    private boolean sameKeyCodeIsTriggered(int keyCode) {
+        return currentPress == keyCode;
+    }
+
+    private boolean isStillUnsupportedCode(int keyCode) {
+        return currentPress == KEY_NEUTRAL && !mappings.contains(keyCode);
+    }
+
+    public boolean onKeyUp(int keyCode) {
+        if (sameKeyCodeIsTriggered(keyCode)) {
+            faceListener.onNewFace(NEUTRAL_EXPRESSION);
+            currentPress = KEY_NEUTRAL;
+        }
+        return true;
+    }
+
+    @Override
+    public void start() {
+        // no-op
+    }
+
+    @Override
+    public void release() {
+        // no-op
+    }
+}

--- a/app/src/main/java/net/bonysoft/magicmirror/facerecognition/KeyboardFaceSource.java
+++ b/app/src/main/java/net/bonysoft/magicmirror/facerecognition/KeyboardFaceSource.java
@@ -18,7 +18,7 @@ public class KeyboardFaceSource implements FaceReactionSource {
         if (sameKeyCodeIsTriggered(keyCode)) {
             return false;
         }
-        FaceExpression faceExpression = mappings.getFace(keyCode);
+        FaceExpression faceExpression = mappings.getFaceFromKeyCode(keyCode);
         if (faceExpression != null) {
             currentExpression = faceExpression;
             faceListener.onNewFace(faceExpression);
@@ -29,7 +29,7 @@ public class KeyboardFaceSource implements FaceReactionSource {
     }
 
     private boolean sameKeyCodeIsTriggered(int keyCode) {
-        FaceExpression mappedExpression = mappings.getFace(keyCode);
+        FaceExpression mappedExpression = mappings.getFaceFromKeyCode(keyCode);
         if (mappedExpression == null) {
             return currentExpression == NEUTRAL_EXPRESSION;
         }

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -12,6 +12,6 @@
   <dimen name="weather_icon_width">150dp</dimen>
   <dimen name="weather_icon_height">150dp</dimen>
 
-  <dimen name="face_recognition_text">100sp</dimen>
+  <dimen name="face_recognition_text">50sp</dimen>
 
 </resources>

--- a/app/src/test/java/net/bonysoft/magicmirror/facerecognition/KeyboardFaceSourceTest.java
+++ b/app/src/test/java/net/bonysoft/magicmirror/facerecognition/KeyboardFaceSourceTest.java
@@ -40,11 +40,14 @@ public class KeyboardFaceSourceTest {
     }
 
     @Test
-    public void givenKeySadIsPressedTwice_thenSadExpressionIsTriggeredOnlyOnce() {
-        // we are testing when user is keep the button pressed
-        source.onKeyDown(CODE_SAD);
-        source.onKeyDown(CODE_SAD);
+    public void givenKeySadIsPressedAndHold_thenSadExpressionIsTriggeredOnlyOnce() {
+        pressAndHold(CODE_SAD);
         verify(mockListener, times(1)).onNewFace(FaceExpression.SAD);
+    }
+
+    private void pressAndHold(int code) {
+        source.onKeyDown(code);
+        source.onKeyDown(code);
     }
 
     @Test

--- a/app/src/test/java/net/bonysoft/magicmirror/facerecognition/KeyboardFaceSourceTest.java
+++ b/app/src/test/java/net/bonysoft/magicmirror/facerecognition/KeyboardFaceSourceTest.java
@@ -34,13 +34,13 @@ public class KeyboardFaceSourceTest {
     }
 
     @Test
-    public void givenKeySadIsPressed_thenSadExpressionIsTriggered() {
+    public void whenKeySadIsPressed_thenSadExpressionIsTriggered() {
         source.onKeyDown(CODE_SAD);
         verify(mockListener).onNewFace(FaceExpression.SAD);
     }
 
     @Test
-    public void givenKeySadIsPressedAndHold_thenSadExpressionIsTriggeredOnlyOnce() {
+    public void whenKeySadIsPressedAndHold_thenSadExpressionIsTriggeredOnlyOnce() {
         pressAndHold(CODE_SAD);
         verify(mockListener, times(1)).onNewFace(FaceExpression.SAD);
     }
@@ -51,20 +51,20 @@ public class KeyboardFaceSourceTest {
     }
 
     @Test
-    public void givenSadKeySadIsPressedAndReleased_thenLookingExpressionIsTriggered() {
-        givenKeySadIsPressed_thenSadExpressionIsTriggered();
+    public void whenSadKeySadIsPressedAndReleased_thenLookingExpressionIsTriggered() {
+        source.onKeyDown(CODE_SAD);
         source.onKeyUp(CODE_SAD);
         verify(mockListener).onNewFace(FaceExpression.LOOKING);
     }
 
     @Test
-    public void givenUnsupportedKeyIsPressed_thenNoCallbacksAreTriggered() {
+    public void whenUnsupportedKeyIsPressed_thenNoCallbacksAreTriggered() {
         source.onKeyDown(1337);
         verify(mockListener, times(0)).onNewFace(any(FaceExpression.class));
     }
 
     @Test
-    public void givenAnUnsupportedKeyIsPressedAfterASupportedKey_thenLookingExpressionIsTriggeredOnlyOnce() {
+    public void whenAnUnsupportedKeyIsPressedAfterASupportedKey_thenLookingExpressionIsTriggeredOnlyOnce() {
         onPressAndReleaseKey(CODE_HAPPY);
         onPressAndReleaseKey(2000);
         verify(mockListener, times(1)).onNewFace(FaceExpression.LOOKING);

--- a/app/src/test/java/net/bonysoft/magicmirror/facerecognition/KeyboardFaceSourceTest.java
+++ b/app/src/test/java/net/bonysoft/magicmirror/facerecognition/KeyboardFaceSourceTest.java
@@ -26,8 +26,8 @@ public class KeyboardFaceSourceTest {
     @Before
     public void setUp() throws Exception {
         source = new KeyboardFaceSource(mockListener, mockMappings);
-        when(mockMappings.getFace(CODE_SAD)).thenReturn(FaceExpression.SAD);
-        when(mockMappings.getFace(CODE_HAPPY)).thenReturn(FaceExpression.HAPPY);
+        when(mockMappings.getFaceFromKeyCode(CODE_SAD)).thenReturn(FaceExpression.SAD);
+        when(mockMappings.getFaceFromKeyCode(CODE_HAPPY)).thenReturn(FaceExpression.HAPPY);
 
         when(mockMappings.contains(CODE_HAPPY)).thenReturn(true);
         when(mockMappings.contains(CODE_SAD)).thenReturn(true);

--- a/app/src/test/java/net/bonysoft/magicmirror/facerecognition/KeyboardFaceSourceTest.java
+++ b/app/src/test/java/net/bonysoft/magicmirror/facerecognition/KeyboardFaceSourceTest.java
@@ -37,7 +37,6 @@ public class KeyboardFaceSourceTest {
     public void givenKeySadIsPressed_thenSadExpressionIsTriggered() {
         source.onKeyDown(CODE_SAD);
         verify(mockListener).onNewFace(FaceExpression.SAD);
-
     }
 
     @Test

--- a/app/src/test/java/net/bonysoft/magicmirror/facerecognition/KeyboardFaceSourceTest.java
+++ b/app/src/test/java/net/bonysoft/magicmirror/facerecognition/KeyboardFaceSourceTest.java
@@ -1,0 +1,84 @@
+package net.bonysoft.magicmirror.facerecognition;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.internal.verification.VerificationModeFactory.times;
+
+@RunWith(MockitoJUnitRunner.class)
+public class KeyboardFaceSourceTest {
+
+    private static final int CODE_SAD = 1;
+    private static final int CODE_HAPPY = 2;
+
+    private KeyboardFaceSource source;
+    @Mock
+    private FaceTracker.FaceListener mockListener;
+    @Mock
+    private KeyToFaceMappings mockMappings;
+
+    @Before
+    public void setUp() throws Exception {
+        source = new KeyboardFaceSource(mockListener, mockMappings);
+        when(mockMappings.getFace(CODE_SAD)).thenReturn(FaceExpression.SAD);
+        when(mockMappings.getFace(CODE_HAPPY)).thenReturn(FaceExpression.HAPPY);
+
+        when(mockMappings.contains(CODE_HAPPY)).thenReturn(true);
+        when(mockMappings.contains(CODE_SAD)).thenReturn(true);
+    }
+
+    @Test
+    public void givenKeySadIsPressed_thenSadExpressionIsTriggered() {
+        source.onKeyDown(CODE_SAD);
+        verify(mockListener).onNewFace(FaceExpression.SAD);
+
+    }
+
+    @Test
+    public void givenKeySadIsPressedTwice_thenSadExpressionIsTriggeredOnlyOnce() {
+        // we are testing when user is keep the button pressed
+        source.onKeyDown(CODE_SAD);
+        source.onKeyDown(CODE_SAD);
+        verify(mockListener, times(1)).onNewFace(FaceExpression.SAD);
+    }
+
+    @Test
+    public void givenSadKeySadIsPressedAndReleased_thenLookingExpressionIsTriggered() {
+        givenKeySadIsPressed_thenSadExpressionIsTriggered();
+        source.onKeyUp(CODE_SAD);
+        verify(mockListener).onNewFace(FaceExpression.LOOKING);
+    }
+
+    @Test
+    public void givenUnsupportedKeyIsPressed_thenNoCallbacksAreTriggered() {
+        source.onKeyDown(1337);
+        verify(mockListener, times(0)).onNewFace(any(FaceExpression.class));
+    }
+
+    @Test
+    public void givenAnUnsupportedKeyIsPressedAfterASupportedKey_thenLookingExpressionIsTriggeredOnlyOnce() {
+        onPressAndReleaseKey(CODE_HAPPY);
+        onPressAndReleaseKey(2000);
+        verify(mockListener, times(1)).onNewFace(FaceExpression.LOOKING);
+    }
+
+    @Test
+    public void givenAnTwoUnsupportedKeyIsPressedAfterAUnSupportedKey_thenLookingExpressionIsTriggeredOnlyOnce() {
+        onPressAndReleaseKey(CODE_HAPPY);
+
+        onPressAndReleaseKey(2001);
+        onPressAndReleaseKey(2002);
+        verify(mockListener, times(1)).onNewFace(FaceExpression.LOOKING);
+    }
+
+    private void onPressAndReleaseKey(int code) {
+        source.onKeyDown(code);
+        source.onKeyUp(code);
+    }
+}


### PR DESCRIPTION
This PR allows the user to trigger any facial expression by using their keyboard only when they are using an emulator.

It contains some tests around the `KeyboardFaceSource`'s different key combinations. 
