### PR TITLE
Gradient glow instead of solid color

### DIFF
--- a/app/src/main/java/net/bonysoft/magicmirror/facerecognition/DummyFaceSource.java
+++ b/app/src/main/java/net/bonysoft/magicmirror/facerecognition/DummyFaceSource.java
@@ -1,0 +1,49 @@
+package net.bonysoft.magicmirror.facerecognition;
+
+import android.os.Handler;
+
+import java.util.Random;
+
+public class DummyFaceSource implements FaceReactionSource {
+
+    private static final int DELAY_MILLIS = 300;
+
+    private final FaceTracker.FaceListener faceListener;
+    private final Handler handler;
+    private final Random smilingProbabilityGenerator;
+
+    private Runnable updateFaceRunnable = new Runnable() {
+        @Override
+        public void run() {
+            FaceExpression expression = FaceExpression.fromSmilingProbability(smilingProbabilityGenerator.nextFloat());
+            faceListener.onNewFace(expression);
+            handler.postDelayed(this, DELAY_MILLIS);
+        }
+    };
+
+    public DummyFaceSource(FaceTracker.FaceListener faceListener, Handler handler) {
+        this.faceListener = faceListener;
+        this.handler = handler;
+        this.smilingProbabilityGenerator = new Random();
+    }
+
+    @Override
+    public void start() {
+        handler.postDelayed(updateFaceRunnable, DELAY_MILLIS);
+    }
+
+    @Override
+    public void release() {
+        handler.removeCallbacks(updateFaceRunnable);
+    }
+
+    @Override
+    public boolean onKeyDown(int keyCode) {
+        return false;
+    }
+
+    @Override
+    public boolean onKeyUp(int keyCode) {
+        return false;
+    }
+}

--- a/app/src/main/java/net/bonysoft/magicmirror/facerecognition/DummyFaceSource.java
+++ b/app/src/main/java/net/bonysoft/magicmirror/facerecognition/DummyFaceSource.java
@@ -12,7 +12,13 @@ public class DummyFaceSource implements FaceReactionSource {
     private final Handler handler;
     private final Random smilingProbabilityGenerator;
 
-    private Runnable updateFaceRunnable = new Runnable() {
+    public DummyFaceSource(FaceTracker.FaceListener faceListener, Handler handler) {
+        this.faceListener = faceListener;
+        this.handler = handler;
+        this.smilingProbabilityGenerator = new Random();
+    }
+
+    private final Runnable updateFaceRunnable = new Runnable() {
         @Override
         public void run() {
             FaceExpression expression = FaceExpression.fromSmilingProbability(smilingProbabilityGenerator.nextFloat());
@@ -20,12 +26,6 @@ public class DummyFaceSource implements FaceReactionSource {
             handler.postDelayed(this, DELAY_MILLIS);
         }
     };
-
-    public DummyFaceSource(FaceTracker.FaceListener faceListener, Handler handler) {
-        this.faceListener = faceListener;
-        this.handler = handler;
-        this.smilingProbabilityGenerator = new Random();
-    }
 
     @Override
     public void start() {

--- a/app/src/main/java/net/bonysoft/magicmirror/sfx/GlowView.java
+++ b/app/src/main/java/net/bonysoft/magicmirror/sfx/GlowView.java
@@ -1,20 +1,25 @@
 package net.bonysoft.magicmirror.sfx;
 
 import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Color;
+import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
+import android.graphics.drawable.GradientDrawable;
 import android.graphics.drawable.TransitionDrawable;
 import android.support.annotation.ColorInt;
 import android.support.annotation.ColorRes;
 import android.support.v4.util.SparseArrayCompat;
 import android.util.AttributeSet;
-import android.view.View;
+import android.widget.ImageView;
 
-public class GlowView extends View {
+public class GlowView extends ImageView {
 
     private static final int TRANSITION_DURATION = 700;
 
-    private final SparseArrayCompat<ColorDrawable> colors = new SparseArrayCompat<>();
+    private final SparseArrayCompat<BitmapDrawable> colors = new SparseArrayCompat<>();
 
     public GlowView(Context context, AttributeSet attrs) {
         super(context, attrs);
@@ -23,30 +28,57 @@ public class GlowView extends View {
     public void transitionToColor(@ColorRes int colorRes) {
         // TODO timeout if too fast
         Drawable previousBackground = getPreviousDrawableSafely();
-        TransitionDrawable transitionDrawable = new TransitionDrawable(new Drawable[]{
-                previousBackground,
-                getOrCreateColorDrawableFor(colorRes)
-        });
-        setBackground(transitionDrawable);
+        TransitionDrawable transitionDrawable = createTransitionDrawable(previousBackground, colorRes);
+
+        setImageDrawable(transitionDrawable);
         transitionDrawable.startTransition(TRANSITION_DURATION);
     }
 
-    private ColorDrawable getOrCreateColorDrawableFor(@ColorRes int colorRes) {
-        ColorDrawable colorDrawable = colors.get(colorRes);
-        if (colorDrawable == null) {
-            colorDrawable = new ColorDrawable(getColor(colorRes));
-            colors.put(colorRes, colorDrawable);
-        }
-        return colorDrawable;
-    }
-
     private Drawable getPreviousDrawableSafely() {
-        Drawable previousDrawable = getBackground();
+        Drawable previousDrawable = getDrawable();
         if (previousDrawable == null) {
             int transparentRes = getColor(android.R.color.transparent);
             return new ColorDrawable(transparentRes);
+        } else {
+            TransitionDrawable previousTransitionDrawable = (TransitionDrawable) previousDrawable;
+            int idOfFrontDrawable = previousTransitionDrawable.getId(1);
+            return previousTransitionDrawable.findDrawableByLayerId(idOfFrontDrawable);
         }
-        return previousDrawable;
+    }
+
+    private TransitionDrawable createTransitionDrawable(Drawable previousBackground, @ColorRes int colorRes) {
+        return new TransitionDrawable(new Drawable[]{
+                previousBackground,
+                getOrCreateColorDrawableFor(colorRes)
+        });
+    }
+
+    private BitmapDrawable getOrCreateColorDrawableFor(@ColorRes int colorRes) {
+        BitmapDrawable bitmapDrawable = colors.get(colorRes);
+        if (bitmapDrawable == null) {
+            GradientDrawable gradientDrawable = new GradientDrawable();
+            gradientDrawable.setGradientType(GradientDrawable.RADIAL_GRADIENT);
+            gradientDrawable.setGradientRadius(getWidth() / 2);
+            gradientDrawable.setColors(new int[]{
+                    getColor(colorRes),
+                    Color.BLACK
+            });
+
+            Bitmap bitmap = drawableToBitmap(gradientDrawable);
+            bitmapDrawable = new BitmapDrawable(getResources(), bitmap);
+
+            colors.put(colorRes, bitmapDrawable);
+        }
+        return bitmapDrawable;
+    }
+
+    private Bitmap drawableToBitmap(Drawable drawable) {
+        Bitmap bitmap = Bitmap.createBitmap(getWidth(), getWidth(), Bitmap.Config.ARGB_8888);
+
+        Canvas canvas = new Canvas(bitmap);
+        drawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
+        drawable.draw(canvas);
+        return bitmap;
     }
 
     @ColorInt

--- a/app/src/main/java/net/bonysoft/magicmirror/sfx/GlowView.java
+++ b/app/src/main/java/net/bonysoft/magicmirror/sfx/GlowView.java
@@ -58,7 +58,7 @@ public class GlowView extends ImageView {
         if (bitmapDrawable == null) {
             GradientDrawable gradientDrawable = new GradientDrawable();
             gradientDrawable.setGradientType(GradientDrawable.RADIAL_GRADIENT);
-            gradientDrawable.setGradientRadius(getWidth() / 2);
+            gradientDrawable.setGradientRadius(getWidth() / 4);
             gradientDrawable.setColors(new int[]{
                     getColor(colorRes),
                     Color.BLACK
@@ -73,7 +73,7 @@ public class GlowView extends ImageView {
     }
 
     private Bitmap drawableToBitmap(Drawable drawable) {
-        Bitmap bitmap = Bitmap.createBitmap(getWidth(), getWidth(), Bitmap.Config.ARGB_8888);
+        Bitmap bitmap = Bitmap.createBitmap(getWidth() / 2, getWidth() / 2, Bitmap.Config.RGB_565);
 
         Canvas canvas = new Canvas(bitmap);
         drawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());

--- a/app/src/main/java/net/bonysoft/magicmirror/sfx/GlowView.java
+++ b/app/src/main/java/net/bonysoft/magicmirror/sfx/GlowView.java
@@ -19,7 +19,7 @@ public class GlowView extends ImageView {
 
     private static final int TRANSITION_DURATION = 700;
 
-    private final SparseArrayCompat<BitmapDrawable> colors = new SparseArrayCompat<>();
+    private final SparseArrayCompat<BitmapDrawable> bitmapDrawables = new SparseArrayCompat<>();
 
     public GlowView(Context context, AttributeSet attrs) {
         super(context, attrs);
@@ -49,12 +49,12 @@ public class GlowView extends ImageView {
     private TransitionDrawable createTransitionDrawable(Drawable previousBackground, @ColorRes int colorRes) {
         return new TransitionDrawable(new Drawable[]{
                 previousBackground,
-                getOrCreateColorDrawableFor(colorRes)
+                getOrCreateBitmapDrawableFor(colorRes)
         });
     }
 
-    private BitmapDrawable getOrCreateColorDrawableFor(@ColorRes int colorRes) {
-        BitmapDrawable bitmapDrawable = colors.get(colorRes);
+    private BitmapDrawable getOrCreateBitmapDrawableFor(@ColorRes int colorRes) {
+        BitmapDrawable bitmapDrawable = bitmapDrawables.get(colorRes);
         if (bitmapDrawable == null) {
             GradientDrawable gradientDrawable = new GradientDrawable();
             gradientDrawable.setGradientType(GradientDrawable.RADIAL_GRADIENT);
@@ -67,7 +67,7 @@ public class GlowView extends ImageView {
             Bitmap bitmap = drawableToBitmap(gradientDrawable);
             bitmapDrawable = new BitmapDrawable(getResources(), bitmap);
 
-            colors.put(colorRes, bitmapDrawable);
+            bitmapDrawables.put(colorRes, bitmapDrawable);
         }
         return bitmapDrawable;
     }

--- a/app/src/main/res/layout/activity_face_recognition.xml
+++ b/app/src/main/res/layout/activity_face_recognition.xml
@@ -13,6 +13,7 @@
   <net.bonysoft.magicmirror.sfx.GlowView
     android:id="@+id/glow_background"
     android:layout_width="match_parent"
+    android:scaleType="fitXY"
     android:layout_height="match_parent"
     android:background="@color/activity_background" />
 


### PR DESCRIPTION
Previously we were showing a solid color as a background of the whole screen when a new FaceExpression was detected.
Now we display a circular gradient ending on black, so that it's not cut by the end of the tablet display.
Also, we added a Dummy FaceSource in order to test infinite changes of Face expressions.
### Screenshot

![glow](https://cloud.githubusercontent.com/assets/3942812/16340926/7adb9728-3a22-11e6-9a6b-5c572157e83d.png)
